### PR TITLE
fix Extract

### DIFF
--- a/packages/package-flyway.yaml
+++ b/packages/package-flyway.yaml
@@ -28,25 +28,23 @@ pipeline:
     runs: |
       set -e
       FLYWAY_VERSION="${{package.version}}"
-      FLYWAY_VERSIONED_DIR="/opt/flyway-${FLYWAY_VERSION}"
       
-      # Create versioned installation directory
-      mkdir -p "${{targets.destdir}}${FLYWAY_VERSIONED_DIR}"
+      # Extract Flyway (archive contains flyway-X.Y.Z/ directory)
+      tar -xzf "flyway-commandline-${FLYWAY_VERSION}.tar.gz"
       
-      # Extract Flyway
-      tar -xzf "flyway-commandline-${FLYWAY_VERSION}.tar.gz" \
-        -C "${{targets.destdir}}${FLYWAY_VERSIONED_DIR}" \
-        --strip-components=1
+      # Move extracted directory to versioned location
+      mkdir -p "${{targets.destdir}}/opt"
+      mv "flyway-${FLYWAY_VERSION}" "${{targets.destdir}}/opt/flyway-${FLYWAY_VERSION}"
       
       # Make flyway executable
-      chmod +x "${{targets.destdir}}${FLYWAY_VERSIONED_DIR}/flyway"
+      chmod +x "${{targets.destdir}}/opt/flyway-${FLYWAY_VERSION}/flyway"
       
       # Create generic symlink for easier version management
-      ln -s "${FLYWAY_VERSIONED_DIR}" "${{targets.destdir}}/opt/flyway"
+      ln -s "/opt/flyway-${FLYWAY_VERSION}" "${{targets.destdir}}/opt/flyway"
       
-      # Create symlink for easy access (point directly to versioned executable)
+      # Create symlink in /usr/local/bin for global access
       mkdir -p "${{targets.destdir}}/usr/local/bin"
-      ln -s "${FLYWAY_VERSIONED_DIR}/flyway" \
+      ln -s "/opt/flyway-${FLYWAY_VERSION}/flyway" \
         "${{targets.destdir}}/usr/local/bin/flyway"
 
 test:


### PR DESCRIPTION
## Summary by Sourcery

Adjust Flyway package installation to extract the archive into the working directory and then move the versioned directory into the target root, updating executable permissions and symlinks accordingly.

Enhancements:
- Simplify Flyway extraction by unpacking the archive in-place and moving the resulting versioned directory into the destination tree.
- Update Flyway binary and symlink paths to use absolute /opt locations within the package root for easier access and version management.